### PR TITLE
Updated git clone URL in README.md file[For Issue #11]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ flutter doctor -v
 2. Clone the project
 
 ```
-git clone https://github.com/joshuamdeguzman/semaphoreci_flutter_demo
+git clone https://github.com/semaphoreci-demos/semaphore-demo-flutter2
 ```
 
 3. Install dependencies


### PR DESCRIPTION
### For Issue: 
#11 

### Description:
The following section in the README.md file has the incorrect URL for cloning the application:
```
git clone https://github.com/joshuamdeguzman/semaphoreci_flutter_demo
```

### What Changed:
I updated the above URL with the correct clone URL in the README.md file:
```
git clone https://github.com/semaphoreci-demos/semaphore-demo-flutter2
```
### How Has This Been Tested?
I didn't run any tests as this is only a `README.md` file change.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update